### PR TITLE
remove verbose option from ocamlmklib calls

### DIFF
--- a/lib/project.ml
+++ b/lib/project.ml
@@ -749,7 +749,7 @@ let build_lib (x:lib) =
             Filename.normalize
           in
           Rule.rule ~deps:(deps@clibs) ~prods:[prod] (fun _ _ ->
-            ocamlmklib ~verbose:() ~o deps
+            ocamlmklib ~o deps
           )
         );
 
@@ -762,7 +762,7 @@ let build_lib (x:lib) =
             Filename.normalize
           in
           Rule.rule ~deps ~prods:clibs (fun _ _ ->
-            ocamlmklib ~verbose:() ~o deps
+            ocamlmklib ~o deps
           )
         )
       )


### PR DESCRIPTION
These are probably remnants from debugging the inclusion of C code. I guess they can be safely removed now.