### PR TITLE
Project.merlin_file: added short-paths option

### DIFF
--- a/lib/project.ml
+++ b/lib/project.ml
@@ -277,9 +277,11 @@ end
 (******************************************************************************)
 type content = string list
 
-let merlin_file items : string list =
+let merlin_file ?short_paths items : string list =
   [
     ["B +threads"; "PKG solvuu-build"];
+
+    (if short_paths = Some () then ["FLG -short-paths"] else []) ;
 
     (* libs *)
     List.map (filter_libs items) ~f:(fun x ->

--- a/lib/project.mli
+++ b/lib/project.mli
@@ -141,7 +141,7 @@ val app
 type content = string list
 (** Content of a file represented as a list of lines. *)
 
-val merlin_file : item list -> content
+val merlin_file : ?short_paths:unit -> item list -> content
 
 val meta_file : version:string -> lib list -> Fl_metascanner.pkg_expr option
 (** Return a findlib META file for given libs, where [version] should


### PR DESCRIPTION
`-short-paths` is also very convenient when using `merlin`. This commit introduces an option to the function that generates `merlin`'s configuration file to add the corresponding flag.