### PR TITLE
added support for ocamlc option -no-check-prims

### DIFF
--- a/lib/project.ml
+++ b/lib/project.ml
@@ -32,6 +32,7 @@ type app = {
   inline_max_unroll : string option;
   inline_prim_cost : string option;
   inlining_report : unit option;
+  no_check_prims : unit option ;
   no_unbox_free_vars_of_closures : unit option;
   no_unbox_specialised_args : unit option;
   optimize_classic : unit option;
@@ -80,6 +81,7 @@ and lib = {
   inline_max_unroll : string option;
   inline_prim_cost : string option;
   inlining_report : unit option;
+  no_check_prims : unit option ;
   no_unbox_free_vars_of_closures : unit option;
   no_unbox_specialised_args : unit option;
   optimize_classic : unit option;
@@ -120,6 +122,7 @@ type 'a with_options =
   -> ?inline_max_unroll:string
   -> ?inline_prim_cost:string
   -> ?inlining_report:unit
+  -> ?no_check_prims:unit
   -> ?no_unbox_free_vars_of_closures:unit
   -> ?no_unbox_specialised_args:unit
   -> ?optimize_classic:unit
@@ -144,6 +147,7 @@ let lib
     ?inline_call_cost ?inline_indirect_cost ?inline_lifting_benefit
     ?inline_max_depth ?inline_max_unroll ?inline_prim_cost
     ?inlining_report
+    ?no_check_prims
     ?no_unbox_free_vars_of_closures ?no_unbox_specialised_args
     ?optimize_classic ?optimize2 ?optimize3
     ?remove_unused_arguments ?rounds
@@ -194,7 +198,7 @@ let lib
     inline_alloc_cost; inline_branch_cost; inline_branch_factor;
     inline_call_cost; inline_indirect_cost; inline_lifting_benefit;
     inline_max_depth; inline_max_unroll; inline_prim_cost;
-    inlining_report;
+    inlining_report; no_check_prims ;
     no_unbox_free_vars_of_closures; no_unbox_specialised_args;
     optimize_classic; optimize2; optimize3;
     remove_unused_arguments; rounds;
@@ -208,7 +212,7 @@ let app
     ?inline_alloc_cost ?inline_branch_cost ?inline_branch_factor
     ?inline_call_cost ?inline_indirect_cost ?inline_lifting_benefit
     ?inline_max_depth ?inline_max_unroll ?inline_prim_cost
-    ?inlining_report
+    ?inlining_report ?no_check_prims
     ?no_unbox_free_vars_of_closures ?no_unbox_specialised_args
     ?optimize_classic ?optimize2 ?optimize3
     ?remove_unused_arguments ?rounds
@@ -224,7 +228,7 @@ let app
     inline_alloc_cost; inline_branch_cost; inline_branch_factor;
     inline_call_cost; inline_indirect_cost; inline_lifting_benefit;
     inline_max_depth; inline_max_unroll; inline_prim_cost;
-    inlining_report;
+    inlining_report; no_check_prims ;
     no_unbox_free_vars_of_closures; no_unbox_specialised_args;
     optimize_classic; optimize2; optimize3;
     remove_unused_arguments; rounds;
@@ -961,6 +965,7 @@ let build_lib (x:lib) =
   let inline_max_unroll = x.inline_max_unroll in
   let inline_prim_cost = x.inline_prim_cost in
   let inlining_report = x.inlining_report in
+  let no_check_prims = x.no_check_prims in
   let no_unbox_free_vars_of_closures = x.no_unbox_free_vars_of_closures in
   let no_unbox_specialised_args = x.no_unbox_specialised_args in
   let optimize_classic = x.optimize_classic in
@@ -986,7 +991,7 @@ let build_lib (x:lib) =
       ?pack ?o ?a ?c ?pathI ?package ?for_pack ?custom
       ?annot ?bin_annot ?cc ?cclib ?ccopt
       ?color ?g ?safe_string ?short_paths ?strict_formats ?strict_sequence
-      ?thread ?w ?warn_error ?linkall
+      ?thread ?w ?warn_error ?linkall ?no_check_prims
   in
 
   let ocamlopt ?pack ?o ?a ?shared ?c ?pathI ?package ?for_pack files =
@@ -1228,6 +1233,7 @@ let build_app (x:app) =
   let inline_max_unroll = x.inline_max_unroll in
   let inline_prim_cost = x.inline_prim_cost in
   let inlining_report = x.inlining_report in
+  let no_check_prims = x.no_check_prims in
   let no_unbox_free_vars_of_closures = x.no_unbox_free_vars_of_closures in
   let no_unbox_specialised_args = x.no_unbox_specialised_args in
   let optimize_classic = x.optimize_classic in

--- a/lib/project.mli
+++ b/lib/project.mli
@@ -79,6 +79,7 @@ type app = {
   inline_max_unroll : string option;
   inline_prim_cost : string option;
   inlining_report : unit option;
+  no_check_prims : unit option ;
   no_unbox_free_vars_of_closures : unit option;
   no_unbox_specialised_args : unit option;
   optimize_classic : unit option;
@@ -127,6 +128,7 @@ and lib = {
   inline_max_unroll : string option;
   inline_prim_cost : string option;
   inlining_report : unit option;
+  no_check_prims : unit option ;
   no_unbox_free_vars_of_closures : unit option;
   no_unbox_specialised_args : unit option;
   optimize_classic : unit option;
@@ -167,6 +169,7 @@ type 'a with_options =
   -> ?inline_max_unroll:string
   -> ?inline_prim_cost:string
   -> ?inlining_report:unit
+  -> ?no_check_prims:unit
   -> ?no_unbox_free_vars_of_closures:unit
   -> ?no_unbox_specialised_args:unit
   -> ?optimize_classic:unit

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -314,6 +314,7 @@ type 'a ocamlc_args = (
   ?dllib:string ->
   ?dllpath:string ->
   ?vmthread:unit ->
+  ?no_check_prims:unit ->
   'a
 ) ocaml_compiler_args
 
@@ -323,7 +324,8 @@ let ocamlc_args_specs
     ?a ?absname ?annot ?bin_annot ?c ?cc ?cclib ?ccopt ?color
     ?config ?for_pack ?g ?i ?pathI
     ?impl ?intf ?intf_suffix ?labels ?linkall ?make_runtime
-    ?no_alias_deps ?no_app_funct ?noassert ?noautolink ?nolabels
+    ?no_alias_deps ?no_app_funct ?no_check_prims ?noassert
+    ?noautolink ?nolabels
     ?nostdlib ?o ?open_ ?output_obj ?pack ?pp ?ppx ?principal
     ?rectypes ?runtime_variant ?safe_string ?short_paths
     ?strict_sequence ?strict_formats ?thread ?unsafe
@@ -360,6 +362,7 @@ let ocamlc_args_specs
     string "-dllib" dllib;
     string "-dllpath" dllpath;
     unit "-vmthread" vmthread;
+    unit "-no-check-prims" no_check_prims;
   ]
 
 let ocamlc
@@ -379,7 +382,7 @@ let ocamlc
     ?help
 
     (* ocamlc_args *)
-    ?compat_32 ?custom ?dllib ?dllpath ?vmthread
+    ?compat_32 ?custom ?dllib ?dllpath ?vmthread ?no_check_prims
 
     files
   =
@@ -388,7 +391,8 @@ let ocamlc
      ?a ?absname ?annot ?bin_annot ?c ?cc ?cclib ?ccopt ?color
      ?config ?custom ?dllib ?dllpath ?for_pack ?g ?i ?pathI
      ?impl ?intf ?intf_suffix ?labels ?linkall ?make_runtime
-     ?no_alias_deps ?no_app_funct ?noassert ?noautolink ?nolabels
+     ?no_alias_deps ?no_app_funct ?no_check_prims ?noassert
+     ?noautolink ?nolabels
      ?nostdlib ?o ?open_ ?output_obj ?pack ?pp ?ppx ?principal
      ?rectypes ?runtime_variant ?safe_string ?short_paths
      ?strict_sequence ?strict_formats ?thread ?unsafe
@@ -425,7 +429,7 @@ let ocamlfind_ocamlc
     ?help
 
     (* ocamlc_args *)
-    ?compat_32 ?custom ?dllib ?dllpath ?vmthread
+    ?compat_32 ?custom ?dllib ?dllpath ?vmthread ?no_check_prims
 
     files
   =
@@ -434,7 +438,8 @@ let ocamlfind_ocamlc
       ?a ?absname ?annot ?bin_annot ?c ?cc ?cclib ?ccopt ?color
       ?config ?for_pack ?g ?i ?pathI
       ?impl ?intf ?intf_suffix ?labels ?linkall ?make_runtime
-      ?no_alias_deps ?no_app_funct ?noassert ?noautolink ?nolabels
+      ?no_alias_deps ?no_app_funct ?no_check_prims ?noassert
+      ?noautolink ?nolabels
       ?nostdlib ?o ?open_ ?output_obj ?pack ?pp ?ppx ?principal
       ?rectypes ?runtime_variant ?safe_string ?short_paths
       ?strict_sequence ?strict_formats ?thread ?unsafe
@@ -1318,7 +1323,7 @@ let eliomc
     ?help
 
     (* ocamlc_args *)
-    ?compat_32 ?custom ?dllib ?dllpath ?vmthread
+    ?compat_32 ?custom ?dllib ?dllpath ?vmthread ?no_check_prims
 
     files
   =
@@ -1341,7 +1346,7 @@ let eliomc
       ?nopervasives ?dsource ?dparsetree ?dtypedtree
       ?drawlambda ?dlambda ?dinstr
       ?help
-      ?compat_32 ?custom ?dllib ?dllpath ?vmthread ()
+      ?compat_32 ?custom ?dllib ?dllpath ?vmthread ?no_check_prims ()
    )
   @[List.map files ~f:(fun x -> Some (A x))]
   |> specs_to_command
@@ -1658,7 +1663,7 @@ let js_of_eliom
     ?help
 
     (* ocamlc_args *)
-    ?compat_32 ?custom ?dllib ?dllpath ?vmthread
+    ?compat_32 ?custom ?dllib ?dllpath ?vmthread ?no_check_prims
 
     files
   =
@@ -1692,7 +1697,7 @@ let js_of_eliom
       ?nopervasives ?dsource ?dparsetree ?dtypedtree
       ?drawlambda ?dlambda ?dinstr
       ?help
-      ?compat_32 ?custom ?dllib ?dllpath ?vmthread ()
+      ?compat_32 ?custom ?dllib ?dllpath ?vmthread ?no_check_prims ()
    )
   @[List.map files ~f:(fun x -> Some (A x))]
   |> specs_to_command

--- a/lib/tools.mli
+++ b/lib/tools.mli
@@ -144,6 +144,7 @@ type 'a ocamlc_args = (
   ?dllib:string ->
   ?dllpath:string ->
   ?vmthread:unit ->
+  ?no_check_prims:unit ->
   'a
 ) ocaml_compiler_args
 


### PR DESCRIPTION
This option is useful for cross-compiling in general, and js_of_ocaml
in particular.